### PR TITLE
Update go.mod to use go 1.22.2 that supports loopvar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumackey/kiriban
 
-go 1.20
+go 1.22.2
 
 require github.com/stretchr/testify v1.7.0
 


### PR DESCRIPTION
## 更新内容

go.mod に記載している Go バージョンを 1.22.2 にしました。以下のコマンドを使いました。
```console
go get go@1.22
```

## 補足

テストの中で、いわゆる `tt := tt` にあたるものが記載されていないことに気付きました。
`tt := tt` のようなものを補ってもいいのですが、Go 1.22 以降を用いればこのイディオムは記載する必要がないので、いまだったら Go 1.22 以降を使うように更新したほうが筋がいいかな、と思いました。ので、go.mod で Go 1.22.2 を使うように指定してみましたがいかがでしょうか！